### PR TITLE
Support touch close for settings menu

### DIFF
--- a/src/components/SettingsMenu.jsx
+++ b/src/components/SettingsMenu.jsx
@@ -18,8 +18,10 @@ export default function SettingsMenu({ user }) {
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- close settings menu on `touchstart`

## Testing
- `npx vitest run --silent` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6853373b2230832d9957938a31454337